### PR TITLE
Feature/oracle credential on vault

### DIFF
--- a/.github/workflows/build-test-create.yml
+++ b/.github/workflows/build-test-create.yml
@@ -18,7 +18,6 @@ jobs:
     outputs:
       IMAGE_TO_DEPLOY: ${{ steps.meta.outputs.tags }}
     steps:
-      - uses: actions/checkout@v3
       - name: Checkout source code
         uses: actions/checkout@v3
       - name: Set up Docker Buildx
@@ -43,9 +42,9 @@ jobs:
             maintainer=seano@slac.stanford.edu
       - name: Extract some files
         run: 7z x client.zip
-      - name: 'Create env file'
-        run: |
-          echo "${{ secrets.ENV_FILE }}" > .env
+      # - name: 'Create env file'
+      #   run: |
+      #     echo "${{ secrets.ENV_FILE }}" > .env
       - name: Build and push Docker image
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,21 +16,3 @@ jobs:
       steps:
         - name: Checkout source code
           uses: actions/checkout@v3
-        - uses: actions/setup-java@v3
-          with:
-            distribution: temurin
-            java-version: 19
-        - name: Build Project
-          uses: gradle/gradle-build-action@v2
-          env:
-            CI: true
-          with:
-            gradle-version: 7.6
-            arguments: assemble
-        - name: Test Project
-          uses: gradle/gradle-build-action@v2
-          env:
-            CI: true
-          with:
-            gradle-version: 7.6
-            arguments: test

--- a/test/deployment.yaml
+++ b/test/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: smartcaptar-back
         imagePullPolicy: Always
-        image: ghcr.io/slaclab/smartcaptar-back:sha-76e7930
+        image: ghcr.io/slaclab/smartcaptar-back:sha-c562479
         envFrom:
         - configMapRef:
             name: env-config-map

--- a/test/deployment.yaml
+++ b/test/deployment.yaml
@@ -29,7 +29,7 @@ spec:
         - containerPort: 1337
         volumeMounts:
           - mountPath: "/myapp/.env-oracle-credential"
-            name: oracle-credential
+            name: envfile
             readOnly: true
       imagePullSecrets:
         - name: github-secret

--- a/test/deployment.yaml
+++ b/test/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         ports:
         - containerPort: 1337
         volumeMounts:
-          - mountPath: "/myapp/.env-oracle-credential"
+          - mountPath: "/tmp/env-oracle-credential"
             name: envfile
             readOnly: true
       imagePullSecrets:

--- a/test/deployment.yaml
+++ b/test/deployment.yaml
@@ -27,5 +27,13 @@ spec:
             cpu: "250m"
         ports:
         - containerPort: 1337
+        volumeMounts:
+          - mountPath: "/myapp/.env-oracle-credential"
+            name: oracle-credential
+            readOnly: true
       imagePullSecrets:
-      - name: github-secret
+        - name: github-secret
+      volumes:
+        - name: envfile
+          secret:
+            secretName: oracle-credential  

--- a/test/docker-config-secrets.yaml
+++ b/test/docker-config-secrets.yaml
@@ -3,7 +3,7 @@ kind: VaultSecret
 metadata:
   name: github-secret
 spec:
-  path: secret/ad/accel-webapp-dev/elog/github-secret
+  path: secret/ad/accel-webapp-dev/gh-secret
   type: kubernetes.io/dockerconfigjson
   keys:
     - username

--- a/test/env-config-map.yaml
+++ b/test/env-config-map.yaml
@@ -4,4 +4,4 @@ metadata:
   name: env-config-map
 data:
   # property-like keys; each key maps to a simple value
-  ENV_NAME: value
+  ORACLE_CREDENTIAL_ENV: /tmp/env-oracle-credential/.env

--- a/test/ingress.yaml
+++ b/test/ingress.yaml
@@ -4,6 +4,7 @@ metadata:
   name: smartcaptar-back-ingress
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/whitelist-source-range: 134.79.0.0/16,172.16.0.0/12
   labels:
     name: smartcaptar-back-ingress
 spec:

--- a/test/kustomization.yaml
+++ b/test/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
 - env-config-map.yaml
 - docker-config-secrets.yaml
 - ingress.yaml
+- oracle-creadential.yaml

--- a/test/oracle-creadential.yaml
+++ b/test/oracle-creadential.yaml
@@ -3,7 +3,7 @@ kind: VaultSecret
 metadata:
   name: oracle-credential
 spec:
-  path: ad/accel-webapp-dev/smart-captar/oracle-credential
+  path: secret/ad/accel-webapp-dev/smart-captar/oracle-credential
   type: Opaque
   keys:
     - USER

--- a/test/oracle-creadential.yaml
+++ b/test/oracle-creadential.yaml
@@ -10,5 +10,5 @@ spec:
     - PASSWORD
   templates:
     ".env": |
-      USER="{% .Secrets.USER %}"
-      PASSWORD="{% .Secrets.PASSWORD %}"
+      USER={% .Secrets.USER %}
+      PASSWORD={% .Secrets.PASSWORD %}

--- a/test/oracle-creadential.yaml
+++ b/test/oracle-creadential.yaml
@@ -9,6 +9,6 @@ spec:
     - USER
     - PASSWORD
   templates:
-    "env_oracle": |
+    ".env": |
       USER="{% .Secrets.USER %}"
       PASSWORD="{% .Secrets.PASSWORD %}"

--- a/test/oracle-creadential.yaml
+++ b/test/oracle-creadential.yaml
@@ -1,0 +1,14 @@
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: oracle-credential
+spec:
+  path: ad/accel-webapp-dev/smart-captar/oracle-credential
+  type: Opaque
+  keys:
+    - USER
+    - PASSWORD
+  templates:
+    "env_oracle": |
+      USER="{% .Secrets.USER %}"
+      PASSWORD="{% .Secrets.PASSWORD %}"


### PR DESCRIPTION
- removed .env on the docker container
- use of ORACLE_CREDENTIAL_ENV to configure the backend where to get the oracle credential
- oracle credential are now managed by valut